### PR TITLE
Module variables abstraction

### DIFF
--- a/KeypadDriver/KeypadDriver.Gui.au3
+++ b/KeypadDriver/KeypadDriver.Gui.au3
@@ -62,7 +62,7 @@ Func HandleMsg()
         
         ; The "Save to config" button
         Case $_idButtonSave
-            ConfigSave()
+            Return 1
         
         ; The binding action selectors
         Case $_idRadioBind
@@ -138,6 +138,8 @@ Func HandleMsg()
         Case $CONNECTED
             GUICtrlSetData($_idLabelConnection, "Connected to " & GetComPort())
     EndSwitch
+
+    Return 0
 EndFunc
 
 ; This function retrieves the rgb info from the keypad and syncs them to the gui

--- a/KeypadDriver/KeypadDriver.Gui.au3
+++ b/KeypadDriver/KeypadDriver.Gui.au3
@@ -17,37 +17,37 @@
 #include "KeypadDriver.Serial.au3"
 #include "KeypadDriver.Keys.au3"
 
-Global $_guiOpened = False
-Global $_hGui
-Global $_msg
+Global $gui_guiOpened = False
+Global $gui_hGui
+Global $gui_msg
 
-Global $_idButtonBtns[$WIDTH * $HEIGHT]
+Global $gui_idButtonBtns[$WIDTH * $HEIGHT]
 
-Global Enum $_BIND, $_REMOVE
-Global $_bindingAction = $_BIND
-Global $_bindingKeys = False
-Global $_currentlyBinding = 0
-Global $_idGroupBinding, $_idLabelCurrentlyBinding, $_idLabelBindingArrow, $_idLabelBindingStr, $_idInputKeyUp, $_idInputKeyDown, $_idButtonConfirm, $_idButtonCancel
+Global Enum $gui_BIND, $gui_REMOVE
+Global $gui_bindingAction = $gui_BIND
+Global $gui_bindingKeys = False
+Global $gui_currentlyBinding = 0
+Global $gui_idGroupBinding, $gui_idLabelCurrentlyBinding, $gui_idLabelBindingArrow, $gui_idLabelBindingStr, $gui_idInputKeyUp, $gui_idInputKeyDown, $gui_idButtonConfirm, $gui_idButtonCancel
 
-Global $_idRadioBind, $_idRadioRemove
+Global $gui_idRadioBind, $gui_idRadioRemove
 
-Global $_idComboRgbState, $_idButtonRgbUpdate, $_idButtonRgbIncreaseBrightness, $_idButtonRgbDecreaseBrightness
+Global $gui_idComboRgbState, $gui_idButtonRgbUpdate, $gui_idButtonRgbIncreaseBrightness, $gui_idButtonRgbDecreaseBrightness
 
-Global $_idLabelConnection
+Global $gui_idLabelConnection
 
-Global $_idButtonClose, $_idButtonSave
+Global $gui_idButtonClose, $gui_idButtonSave
 
-Global Enum $_UPDATERGBSTATE, $_GETRGBDATA, $_INCREASERGBBRIGHTNESS, $_DECREASERGBBRIGHTNESS
+Global Enum $gui_UPDATERGBSTATE, $gui_GETRGBDATA, $gui_INCREASERGBBRIGHTNESS, $gui_DECREASERGBBRIGHTNESS
 
-Global $_timerGuiBtnRgbSync
-Global $_syncingButtonIndex = 0
-Global $_syncingRgbIndex = 0
-Global $_rgbBuffer[$WIDTH * $HEIGHT][3]
+Global $gui_timerGuiBtnRgbSync
+Global $gui_syncingButtonIndex = 0
+Global $gui_syncingRgbIndex = 0
+Global $gui_rgbBuffer[$WIDTH * $HEIGHT][3]
 
 ; This function handles the gui messages and performs actions accordingly
 Func HandleMsg()
-    $_msg = GUIGetMsg()
-    Switch $_msg
+    $gui_msg = GUIGetMsg()
+    Switch $gui_msg
         ; If no message to handle then simply skip
         Case 0
         
@@ -56,52 +56,52 @@ Func HandleMsg()
             CloseGui()
         
         ; The "Close the driver" button
-        Case $_idButtonClose
+        Case $gui_idButtonClose
             CloseGui()
             Terminate()
         
         ; The "Save to config" button
-        Case $_idButtonSave
+        Case $gui_idButtonSave
             Return 1
         
         ; The binding action selectors
-        Case $_idRadioBind
-            $_bindingAction = $_BIND
-        Case $_idRadioRemove
-            $_bindingAction = $_REMOVE
-            If $_bindingKeys Then
-                $_bindingKeys = False
+        Case $gui_idRadioBind
+            $gui_bindingAction = $gui_BIND
+        Case $gui_idRadioRemove
+            $gui_bindingAction = $gui_REMOVE
+            If $gui_bindingKeys Then
+                $gui_bindingKeys = False
                 ShowBindingGroup(0)
             EndIf
         
         ; The rgb "Update" button
-        Case $_idButtonRgbUpdate
-            SendMsgToKeypad($_UPDATERGBSTATE, ArrayFind($rgbStates, GUICtrlRead($_idComboRgbState)))
+        Case $gui_idButtonRgbUpdate
+            SendMsgToKeypad($gui_UPDATERGBSTATE, ArrayFind($rgbStates, GUICtrlRead($gui_idComboRgbState)))
         
         ; The rgb brightness control buttons
-        Case $_idButtonRgbIncreaseBrightness
-            SendMsgToKeypad($_INCREASERGBBRIGHTNESS, 0)
-        Case $_idButtonRgbDecreaseBrightness
-            SendMsgToKeypad($_DECREASERGBBRIGHTNESS, 0)
+        Case $gui_idButtonRgbIncreaseBrightness
+            SendMsgToKeypad($gui_INCREASERGBBRIGHTNESS, 0)
+        Case $gui_idButtonRgbDecreaseBrightness
+            SendMsgToKeypad($gui_DECREASERGBBRIGHTNESS, 0)
         
         ; Manually handle the other messages
         Case Else
             ; The key buttons
             For $j = 0 To $HEIGHT - 1
                 For $i = 0 To $WIDTH - 1
-                    If $_msg = $_idButtonBtns[$j * $WIDTH + $i] Then
-                        Switch $_bindingAction
+                    If $gui_msg = $gui_idButtonBtns[$j * $WIDTH + $i] Then
+                        Switch $gui_bindingAction
                             ; Open the "Binding" group for the specific key
-                            Case $_BIND
-                                $_bindingKeys = True
-                                $_currentlyBinding = $j * $WIDTH + $i + 1
-                                GUICtrlSetData($_idLabelCurrentlyBinding, "Binding key " & $_currentlyBinding)
-                                GUICtrlSetData($_idInputKeyUp, GetKeybindingForKey($j * $WIDTH + $i + 1, $KEYSTROKEUP))
-                                GUICtrlSetData($_idInputKeyDown, GetKeybindingForKey($j * $WIDTH + $i + 1, $KEYSTROKEDOWN))
+                            Case $gui_BIND
+                                $gui_bindingKeys = True
+                                $gui_currentlyBinding = $j * $WIDTH + $i + 1
+                                GUICtrlSetData($gui_idLabelCurrentlyBinding, "Binding key " & $gui_currentlyBinding)
+                                GUICtrlSetData($gui_idInputKeyUp, GetKeybindingForKey($j * $WIDTH + $i + 1, $KEYSTROKEUP))
+                                GUICtrlSetData($gui_idInputKeyDown, GetKeybindingForKey($j * $WIDTH + $i + 1, $KEYSTROKEDOWN))
                                 ShowBindingGroup(1)
                             
                             ; Remove the bindings for the specific key
-                            Case $_REMOVE
+                            Case $gui_REMOVE
                                 BindRemove($j * $WIDTH + $i + 1)
                                 UpdateBtnLabels()
                         EndSwitch
@@ -111,17 +111,17 @@ Func HandleMsg()
             Next
             
             ; If the "Binding" group is active then handle the binding update buttons
-            If $_bindingKeys Then
+            If $gui_bindingKeys Then
                 ; The binding "Confirm" button, updates the key to new bindings
-                If $_msg = $_idButtonConfirm Then
-                    BindKey($_currentlyBinding, GUICtrlRead($_idInputKeyUp), GUICtrlRead($_idInputKeyDown))
+                If $gui_msg = $gui_idButtonConfirm Then
+                    BindKey($gui_currentlyBinding, GUICtrlRead($gui_idInputKeyUp), GUICtrlRead($gui_idInputKeyDown))
                     UpdateBtnLabels()
-                    $_bindingKeys = False
+                    $gui_bindingKeys = False
                     ShowBindingGroup(0)
                 
                 ; The binding "Cancel" button, closes the "Binding" group
-                ElseIf $_msg = $_idButtonCancel Then
-                    $_bindingKeys = False
+                ElseIf $gui_msg = $gui_idButtonCancel Then
+                    $gui_bindingKeys = False
                     ShowBindingGroup(0)
                 EndIf
             EndIf
@@ -130,13 +130,13 @@ Func HandleMsg()
     ; Update the connection indicator
     Switch $connectionStatus
         Case $NOTCONNECTED
-            GUICtrlSetData($_idLabelConnection, "Not connected, detecting the port...")
+            GUICtrlSetData($gui_idLabelConnection, "Not connected, detecting the port...")
         Case $CONNECTIONFAILED
-            GUICtrlSetData($_idLabelConnection, "Cannot connect to " & GetComPort() & ", retrying...")
+            GUICtrlSetData($gui_idLabelConnection, "Cannot connect to " & GetComPort() & ", retrying...")
         Case $PORTDETECTIONFAILED
-            GUICtrlSetData($_idLabelConnection, "COM port auto detection failed, please make sure you have the keypad plugged in!")
+            GUICtrlSetData($gui_idLabelConnection, "COM port auto detection failed, please make sure you have the keypad plugged in!")
         Case $CONNECTED
-            GUICtrlSetData($_idLabelConnection, "Connected to " & GetComPort())
+            GUICtrlSetData($gui_idLabelConnection, "Connected to " & GetComPort())
     EndSwitch
 
     Return 0
@@ -146,14 +146,14 @@ EndFunc
 Func SyncGuiRgb()
     If $connectionStatus <> $CONNECTED Then Return
     Local $timer = 0
-    If TimerDiff($_timerGuiBtnRgbSync) > 150 Then
-        $_timerGuiBtnRgbSync = TimerInit()
+    If TimerDiff($gui_timerGuiBtnRgbSync) > 150 Then
+        $gui_timerGuiBtnRgbSync = TimerInit()
         
         ; Clear the serial input buffer in case there are still some scrapped bytes
         _CommClearInputBuffer()
-        SendMsgToKeypad($_GETRGBDATA, 0)
-        $_syncingButtonIndex = 0
-        $_syncingRgbIndex = 0
+        SendMsgToKeypad($gui_GETRGBDATA, 0)
+        $gui_syncingButtonIndex = 0
+        $gui_syncingRgbIndex = 0
         $timer = TimerInit()
         
         ; Constantly poll the bytes from serial until all the rgb infos have been received
@@ -162,19 +162,19 @@ Func SyncGuiRgb()
             Do
                 PollData()
             Until IsByteReceived()
-            $_rgbBuffer[$_syncingButtonIndex][$_syncingRgbIndex] = GetByte()
+            $gui_rgbBuffer[$gui_syncingButtonIndex][$gui_syncingRgbIndex] = GetByte()
             ByteProcessed()
-            $_syncingRgbIndex += 1
+            $gui_syncingRgbIndex += 1
             
             ; If 3 bytes have been received, switch to the next button
-            If $_syncingRgbIndex = 3 Then
-                $_syncingRgbIndex = 0
-                $_syncingButtonIndex += 1
+            If $gui_syncingRgbIndex = 3 Then
+                $gui_syncingRgbIndex = 0
+                $gui_syncingButtonIndex += 1
             EndIf
             
             ; If all the buttons' rgb have been received, update the key buttons' colors and return
-            If $_syncingButtonIndex = $WIDTH * $HEIGHT Then
-                UpdateBtnLabelsRgb($_rgbBuffer)
+            If $gui_syncingButtonIndex = $WIDTH * $HEIGHT Then
+                UpdateBtnLabelsRgb($gui_rgbBuffer)
                 Return
             EndIf
             
@@ -190,7 +190,7 @@ EndFunc
 Func UpdateBtnLabels()
     For $j = 0 To $HEIGHT - 1
         For $i = 0 To $WIDTH - 1
-            GUICtrlSetData($_idButtonBtns[$j * $WIDTH + $i], ($j * $WIDTH + $i + 1) & @CRLF & _
+            GUICtrlSetData($gui_idButtonBtns[$j * $WIDTH + $i], ($j * $WIDTH + $i + 1) & @CRLF & _
                                                              GetKeybindingForKey($j * $WIDTH + $i + 1, $KEYSTROKEDOWN))
         Next
     Next
@@ -200,7 +200,7 @@ EndFunc
 Func UpdateBtnLabelsRgb(ByRef $data)
     For $j = 0 To $HEIGHT - 1
         For $i = 0 To $WIDTH - 1
-            GUICtrlSetBkColor($_idButtonBtns[$j * $WIDTH + $i], $data[$j * $WIDTH + $i][0] * 256 * 256 + _
+            GUICtrlSetBkColor($gui_idButtonBtns[$j * $WIDTH + $i], $data[$j * $WIDTH + $i][0] * 256 * 256 + _
                                                                $data[$j * $WIDTH + $i][1] * 256 + _
                                                                $data[$j * $WIDTH + $i][2])
         Next
@@ -210,13 +210,13 @@ EndFunc
 ; This function shows or hides the "Binding" group and the inside controls
 Func ShowBindingGroup($state)
     $state = $state ? $GUI_SHOW : $GUI_HIDE
-    GUICtrlSetState($_idGroupBinding, $state)
-    GUICtrlSetState($_idLabelCurrentlyBinding, $state)
-    GUICtrlSetState($_idLabelBindingArrow, $state)
-    GUICtrlSetState($_idInputKeyUp, $state)
-    GUICtrlSetState($_idInputKeyDown, $state)
-    GUICtrlSetState($_idButtonConfirm, $state)
-    GUICtrlSetState($_idButtonCancel, $state)
+    GUICtrlSetState($gui_idGroupBinding, $state)
+    GUICtrlSetState($gui_idLabelCurrentlyBinding, $state)
+    GUICtrlSetState($gui_idLabelBindingArrow, $state)
+    GUICtrlSetState($gui_idInputKeyUp, $state)
+    GUICtrlSetState($gui_idInputKeyDown, $state)
+    GUICtrlSetState($gui_idButtonConfirm, $state)
+    GUICtrlSetState($gui_idButtonCancel, $state)
 EndFunc
 
 Func SetGuiOpeningKey($key)
@@ -226,16 +226,16 @@ EndFunc
 ; This function creates the gui 
 Func OpenGui()
     ; If gui is already opened, activate the window
-    If $_guiOpened Then Return WinActivate("THE Keypad Control Panel")
+    If $gui_guiOpened Then Return WinActivate("THE Keypad Control Panel")
     
-    $_hGui = GUICreate("THE Keypad Control Panel", 750, 500, Default, Default, Default, $WS_EX_TOPMOST)
-    $_guiOpened = True
+    $gui_hGui = GUICreate("THE Keypad Control Panel", 750, 500, Default, Default, Default, $WS_EX_TOPMOST)
+    $gui_guiOpened = True
     GUICtrlCreateGroup("Buttons", 50, 30, _
                                   15 + 60 + 85 * 3 + 15, _
                                   15 + 60 + 85 * 2 + 15)
         For $j = 0 To $HEIGHT - 1
             For $i = 0 To $WIDTH - 1
-                $_idButtonBtns[$j * $WIDTH + $i] = GUICtrlCreateButton(($j * $WIDTH + $i + 1) & @CRLF & _
+                $gui_idButtonBtns[$j * $WIDTH + $i] = GUICtrlCreateButton(($j * $WIDTH + $i + 1) & @CRLF & _
                                                                        GetKeybindingForKey($j * $WIDTH + $i + 1, $KEYSTROKEDOWN), _
                                                                        50 + 15 + $i * 85, _
                                                                        30 + 15 + $j * 85, _
@@ -246,31 +246,31 @@ Func OpenGui()
     GUICtrlCreateGroup("RGB Controls", 50, (30 + 15 + 60 + 85 * 2 + 15) + 15, _
                                            15 + 150 + 15, _
                                            15 + 25 + 8 + 25 + 15)
-        $_idComboRgbState = GUICtrlCreateCombo("staticLight", 50 + 15, (30 + 15 + 60 + 85 * 2 + 15) + 15 + 15, 150, 25)
-            GUICtrlSetData($_idComboRgbState, _ArrayToString($rgbStates, "|", 1))
-        $_idButtonRgbUpdate = GUICtrlCreateButton("Update", 50 + 15, (30 + 15 + 60 + 85 * 2 + 15) + 15 + 15 + 25 + 8, 100, 25)
-        $_idButtonRgbIncreaseBrightness = GUICtrlCreateButton("+", 50 + 15 + 100 + 10 , (30 + 15 + 60 + 85 * 2 + 15) + 15 + 15 + 25 + 8, 15, 25)
-        $_idButtonRgbDecreaseBrightness = GUICtrlCreateButton("-", 50 + 15 + 100 + 10 + 15 + 10, (30 + 15 + 60 + 85 * 2 + 15) + 15 + 15 + 25 + 8, 15, 25)
+        $gui_idComboRgbState = GUICtrlCreateCombo("staticLight", 50 + 15, (30 + 15 + 60 + 85 * 2 + 15) + 15 + 15, 150, 25)
+            GUICtrlSetData($gui_idComboRgbState, _ArrayToString($rgbStates, "|", 1))
+        $gui_idButtonRgbUpdate = GUICtrlCreateButton("Update", 50 + 15, (30 + 15 + 60 + 85 * 2 + 15) + 15 + 15 + 25 + 8, 100, 25)
+        $gui_idButtonRgbIncreaseBrightness = GUICtrlCreateButton("+", 50 + 15 + 100 + 10 , (30 + 15 + 60 + 85 * 2 + 15) + 15 + 15 + 25 + 8, 15, 25)
+        $gui_idButtonRgbDecreaseBrightness = GUICtrlCreateButton("-", 50 + 15 + 100 + 10 + 15 + 10, (30 + 15 + 60 + 85 * 2 + 15) + 15 + 15 + 25 + 8, 15, 25)
     GUICtrlCreateGroup("", -99, -99, 1, 1)
-    $_idGroupBinding = GUICtrlCreateGroup("Binding", (50 + 15 + 60 + 85 * 3 + 15) + 15, 30, _
+    $gui_idGroupBinding = GUICtrlCreateGroup("Binding", (50 + 15 + 60 + 85 * 3 + 15) + 15, 30, _
                                                      15 + 100 + 15, _
                                                      15 + 15 + 20 + 8 + 20 + 25 + 25 + 8 + 25 + 15)
-        $_idLabelCurrentlyBinding = GUICtrlCreateLabel("Binding key 1", (50 + 15 + 60 + 85 * 3 + 15) + 15 + 15, _
+        $gui_idLabelCurrentlyBinding = GUICtrlCreateLabel("Binding key 1", (50 + 15 + 60 + 85 * 3 + 15) + 15 + 15, _
                                                                         30 + 15, _
                                                                         100, 15)
-        $_idLabelBindingArrow = GUICtrlCreateLabel("=>", (50 + 15 + 60 + 85 * 3 + 15) + 15 + 15, _
+        $gui_idLabelBindingArrow = GUICtrlCreateLabel("=>", (50 + 15 + 60 + 85 * 3 + 15) + 15 + 15, _
                                                          30 + 15 + 30, _
                                                          15, 15)
-        $_idInputKeyUp = GUICtrlCreateInput("{UP up}", (50 + 15 + 60 + 85 * 3 + 15) + 15 + 15 + 10 + 15, _
+        $gui_idInputKeyUp = GUICtrlCreateInput("{UP up}", (50 + 15 + 60 + 85 * 3 + 15) + 15 + 15 + 10 + 15, _
                                                        30 + 15 + 15, _
                                                        75, 20)
-        $_idInputKeyDown = GUICtrlCreateInput("{UP down}", (50 + 15 + 60 + 85 * 3 + 15) + 15 + 15 + 10 + 15, _
+        $gui_idInputKeyDown = GUICtrlCreateInput("{UP down}", (50 + 15 + 60 + 85 * 3 + 15) + 15 + 15 + 10 + 15, _
                                                            30 + 15 + 15 + 20 + 8, _
                                                            75, 20)
-        $_idButtonConfirm = GUICtrlCreateButton("Confirm", (50 + 15 + 60 + 85 * 3 + 15) + 15 + 15, _
+        $gui_idButtonConfirm = GUICtrlCreateButton("Confirm", (50 + 15 + 60 + 85 * 3 + 15) + 15 + 15, _
                                                            30 + 15 + 15 + 20 + 8 + 20 + 25, _
                                                            100, 25)
-        $_idButtonCancel = GUICtrlCreateButton("Cancel", (50 + 15 + 60 + 85 * 3 + 15) + 15 + 15, _
+        $gui_idButtonCancel = GUICtrlCreateButton("Cancel", (50 + 15 + 60 + 85 * 3 + 15) + 15 + 15, _
                                                          30 + 15 + 15 + 20 + 8 + 20 + 25 + 25 + 8, _
                                                          100, 25)
     GUICtrlCreateGroup("", -99, -99, 1, 1)
@@ -279,33 +279,33 @@ Func OpenGui()
                                   0 + 30, _
                                   15 + 100 + 15, _
                                   15 + 15 + 25 * 1 + 15)
-        $_idRadioBind = GUICtrlCreateRadio("Bind to new keys", 750 - 50 - 15 - 100, 30 + 15, 100, 15)
-            GUICtrlSetState($_idRadioBind, $GUI_CHECKED)
-        $_idRadioRemove = GUICtrlCreateRadio("Remove binding", 750 - 50 - 15 - 100, 30 + 15 + 15 + 10, 100, 15)
+        $gui_idRadioBind = GUICtrlCreateRadio("Bind to new keys", 750 - 50 - 15 - 100, 30 + 15, 100, 15)
+            GUICtrlSetState($gui_idRadioBind, $GUI_CHECKED)
+        $gui_idRadioRemove = GUICtrlCreateRadio("Remove binding", 750 - 50 - 15 - 100, 30 + 15 + 15 + 10, 100, 15)
     GUICtrlCreateGroup("", -99, -99, 1, 1)    
-    $_idButtonClose = GUICtrlCreateButton("Close the driver", 750 - 25 - 150, _
+    $gui_idButtonClose = GUICtrlCreateButton("Close the driver", 750 - 25 - 150, _
                                                               500 - 25 - 25, _
                                                               150, 25)
-        GUICtrlSetColor($_idButtonClose, 0xFF0000)
-    $_idButtonSave = GUICtrlCreateButton("Save to config", 750 - 25 - 150 + 25, _
+        GUICtrlSetColor($gui_idButtonClose, 0xFF0000)
+    $gui_idButtonSave = GUICtrlCreateButton("Save to config", 750 - 25 - 150 + 25, _
                                                            500 - 25 - 25 - 25 - 5, _
                                                            100, 25)
-    $_idLabelConnection = GUICtrlCreateLabel("Not connected, detecting the port...", 50, 500 - 25 - 15, 500, 15)
+    $gui_idLabelConnection = GUICtrlCreateLabel("Not connected, detecting the port...", 50, 500 - 25 - 15, 500, 15)
     
     ; Shows the gui
     GUISetState(@SW_SHOW)
     
-    $_timerGuiBtnRgbSync = TimerInit()
+    $gui_timerGuiBtnRgbSync = TimerInit()
 EndFunc
 
 ; This function closes the gui
 Func CloseGui()
-    GUIDelete($_hGui)
-    $_guiOpened = False
+    GUIDelete($gui_hGui)
+    $gui_guiOpened = False
 EndFunc
 
 Func IsGuiOpened()
-    Return $_guiOpened
+    Return $gui_guiOpened
 EndFunc
 
 Func ArrayFind(ByRef $a, $v)

--- a/KeypadDriver/KeypadDriver.Keys.au3
+++ b/KeypadDriver/KeypadDriver.Keys.au3
@@ -57,3 +57,16 @@ Func BindKey($num, $key, $extra = 0x0)
             $_keyMap[$num - 1][$KEYSTROKEDOWN] = $extra
     EndSwitch
 EndFunc
+
+Func ConfigLoad(ByRef $path)
+    For $i = 1 To $WIDTH * $HEIGHT
+        BindKey($i, IniRead($path, "ButtonBindings", "Button" & $i & "Up", ""), IniRead($iniPath, "ButtonBindings", "Button" & $i & "Down", ""))
+    Next
+EndFunc
+
+Func ConfigSave(ByRef $path)
+    For $i = 1 To $WIDTH * $HEIGHT
+        IniWrite($path, "ButtonBindings", "Button" & $i & "Up", GetKeybindingForKey($i, $KEYSTROKEUP))
+        IniWrite($path, "ButtonBindings", "Button" & $i & "Down", GetKeybindingForKey($i, $KEYSTROKEDOWN))
+    Next
+EndFunc

--- a/KeypadDriver/KeypadDriver.Keys.au3
+++ b/KeypadDriver/KeypadDriver.Keys.au3
@@ -60,7 +60,7 @@ EndFunc
 
 Func ConfigLoad(ByRef $path)
     For $i = 1 To $WIDTH * $HEIGHT
-        BindKey($i, IniRead($path, "ButtonBindings", "Button" & $i & "Up", ""), IniRead($iniPath, "ButtonBindings", "Button" & $i & "Down", ""))
+        BindKey($i, IniRead($path, "ButtonBindings", "Button" & $i & "Up", ""), IniRead($path, "ButtonBindings", "Button" & $i & "Down", ""))
     Next
 EndFunc
 

--- a/KeypadDriver/KeypadDriver.Keys.au3
+++ b/KeypadDriver/KeypadDriver.Keys.au3
@@ -12,35 +12,35 @@
 #include "KeypadDriver.Gui.au3"
 
 ; [[keyStrokeUp, keyStrokeDown], ...]
-Global $_keyMap[$WIDTH * $HEIGHT][$keyStrokeAmount]
+Global $keys_keyMap[$WIDTH * $HEIGHT][$keyStrokeAmount]
     For $j = 0 To $HEIGHT - 1
         For $i = 0 To $WIDTH - 1
-            $_keyMap[$j * $WIDTH + $i][$KEYSTROKEUP] = ""
-            $_keyMap[$j * $WIDTH + $i][$KEYSTROKEDOWN] = ""
+            $keys_keyMap[$j * $WIDTH + $i][$KEYSTROKEUP] = ""
+            $keys_keyMap[$j * $WIDTH + $i][$KEYSTROKEDOWN] = ""
         Next
     Next
 
 Func SendKey($num, $state)
     ; Only send the key stroke when the gui isn't opened
-    If $num <= $WIDTH * $HEIGHT And Not IsGuiOpened() And $_keyMap[$num - 1][$state] <> "" Then
-        Send($_keyMap[$num - 1][$state])
+    If $num <= $WIDTH * $HEIGHT And Not IsGuiOpened() And $keys_keyMap[$num - 1][$state] <> "" Then
+        Send($keys_keyMap[$num - 1][$state])
     EndIf
 EndFunc
 
 Func GetKeybindingForKey($num, $state)
     If $num <= $WIDTH * $HEIGHT Then
-        If $_keyMap[$num - 1][$state] = "" Then
+        If $keys_keyMap[$num - 1][$state] = "" Then
             Return "None"
         Else
-            Return $_keyMap[$num - 1][$state]
+            Return $keys_keyMap[$num - 1][$state]
         EndIf
     EndIf
 EndFunc
 
 ; This function removes both up and down strokes from a key
 Func BindRemove($num)
-    $_keyMap[$num - 1][$KEYSTROKEUP] = ""
-    $_keyMap[$num - 1][$KEYSTROKEDOWN] = ""
+    $keys_keyMap[$num - 1][$KEYSTROKEUP] = ""
+    $keys_keyMap[$num - 1][$KEYSTROKEDOWN] = ""
 EndFunc
 
 ; This function takes 2 arguments and binds a character to both up and down strokes of a key
@@ -50,11 +50,11 @@ Func BindKey($num, $key, $extra = 0x0)
     If $num > $WIDTH * $HEIGHT Then Return
     Switch @NumParams
         Case 2
-            $_keyMap[$num - 1][$KEYSTROKEUP] = "{" & $key & " up}"
-            $_keyMap[$num - 1][$KEYSTROKEDOWN] = "{" & $key & " down}"
+            $keys_keyMap[$num - 1][$KEYSTROKEUP] = "{" & $key & " up}"
+            $keys_keyMap[$num - 1][$KEYSTROKEDOWN] = "{" & $key & " down}"
         Case 3
-            $_keyMap[$num - 1][$KEYSTROKEUP] = $key
-            $_keyMap[$num - 1][$KEYSTROKEDOWN] = $extra
+            $keys_keyMap[$num - 1][$KEYSTROKEUP] = $key
+            $keys_keyMap[$num - 1][$KEYSTROKEDOWN] = $extra
     EndSwitch
 EndFunc
 

--- a/KeypadDriver/KeypadDriver.Serial.au3
+++ b/KeypadDriver/KeypadDriver.Serial.au3
@@ -13,11 +13,11 @@
 #include "KeypadDriver.Vars.au3"
 #include "KeypadDriver.Gui.au3"
 
-Global $_keyDataNum, $_keyDataState, $_keyDataReceived = False
+Global $serial_keyDataNum, $serial_keyDataState, $serial_keyDataReceived = False
 
-Global $_byteString = "", $_byte, $_byteReceived = False
+Global $serial_byteString = "", $serial_byte, $serial_byteReceived = False
 
-Global $_comPort
+Global $serial_comPort
 
 ; This function tries to connect to the keypad serial port
 Func Connect()
@@ -26,8 +26,8 @@ Func Connect()
     For $i = 0 To UBound($ports) - 1
         If $ports[$i][1] == "USB-SERIAL CH340" Then
             Local $errorStr = ""
-            $_comPort = $ports[$i][0]
-            _CommSetPort(Int(StringReplace($_comPort, "COM", "")), $errorStr, 19200, 8, "none", 1, 2)
+            $serial_comPort = $ports[$i][0]
+            _CommSetPort(Int(StringReplace($serial_comPort, "COM", "")), $errorStr, 19200, 8, "none", 1, 2)
             
             If Not @error Then
                 ; Connection succeed
@@ -54,21 +54,21 @@ Func PollKeys()
     If $connectionStatus <> $CONNECTED Then Return
     
     ; If there's still unprocessed key data in the buffers, return
-    If $_keyDataReceived Then Return
+    If $serial_keyDataReceived Then Return
     
-    $_byteString = _CommReadByte()
+    $serial_byteString = _CommReadByte()
     If @error = 3 Then
         $connectionStatus = $CONNECTIONFAILED
         Return
     EndIf
-    If $_byteString <> "" Then
-        $_byte = Int($_byteString)
+    If $serial_byteString <> "" Then
+        $serial_byte = Int($serial_byteString)
         
         ; Key status byte - |first 4 bits for key number, 3 zero padding bits, last one bit for pressed state|
-        $_keyDataNum = BitShift($_byte, 4)
-        $_keyDataState = BitAND($_byte, 0x01)
+        $serial_keyDataNum = BitShift($serial_byte, 4)
+        $serial_keyDataState = BitAND($serial_byte, 0x01)
 
-        $_keyDataReceived = True
+        $serial_keyDataReceived = True
     EndIf
 EndFunc
 
@@ -76,18 +76,18 @@ EndFunc
 Func PollData()
     If $connectionStatus <> $CONNECTED Then Return
     
-    ; If there's still unprocessed byte in the buffer $_byte, return
-    If $_byteReceived Then Return
+    ; If there's still unprocessed byte in the buffer $serial_byte, return
+    If $serial_byteReceived Then Return
     
-    $_byteString = _CommReadByte()
+    $serial_byteString = _CommReadByte()
     If @error = 3 Then
         $connectionStatus = $CONNECTIONFAILED
         Return
     EndIf
-    If $_byteString <> "" Then
-        $_byte = Int($_byteString)
-        ; c("Received data $", 1, $_byteString)
-        $_byteReceived = True
+    If $serial_byteString <> "" Then
+        $serial_byte = Int($serial_byteString)
+        ; c("Received data $", 1, $serial_byteString)
+        $serial_byteReceived = True
         Return
     EndIf
 EndFunc
@@ -114,33 +114,33 @@ Func SendMsgToKeypad($type, $data)
 EndFunc
 
 Func GetComPort()
-    Return $_comPort
+    Return $serial_comPort
 EndFunc
 
 Func GetKeyDataNum()
-    Return $_keyDataNum
+    Return $serial_keyDataNum
 EndFunc
 
 Func GetKeyDataState()
-    Return $_keyDataState
+    Return $serial_keyDataState
 EndFunc
 
 Func IsKeyDataReceived()
-    Return $_keyDataReceived
+    Return $serial_keyDataReceived
 EndFunc
 
 Func KeyDataProcessed()
-    $_keyDataReceived = False
+    $serial_keyDataReceived = False
 EndFunc
 
 Func GetByte()
-    Return $_byte
+    Return $serial_byte
 EndFunc
 
 Func IsByteReceived()
-    Return $_byteReceived
+    Return $serial_byteReceived
 EndFunc
 
 Func ByteProcessed()
-    $_byteReceived = False
+    $serial_byteReceived = False
 EndFunc

--- a/KeypadDriver/KeypadDriver.Vars.au3
+++ b/KeypadDriver/KeypadDriver.Vars.au3
@@ -7,9 +7,6 @@
 
 #include-once
 
-; Path to the config file
-Global Const $iniPath = @ScriptDir & "\keypadconfig.ini"
-
 ; Size of the keypad
 Global Const $WIDTH = 4, $HEIGHT = 3
 ; Available rgb states on the keypad

--- a/KeypadDriver/KeypadDriver.au3
+++ b/KeypadDriver/KeypadDriver.au3
@@ -13,19 +13,19 @@
 #include "KeypadDriver.Serial.au3"
 #include "KeypadDriver.Keys.au3"
 
+Global $main_configPath = @ScriptDir & "\keypadconfig.ini"
+Global Const $main_scansPerSec = 1000
+Global Const $main_msPerScan = 1000 / $main_scansPerSec
+Global $main_loopPeriod, $main_loopStartTime, $main_timer
+Global $main_timerRetrying
+	
 SetGuiOpeningKey("{F4}")
 Opt("GUICloseOnESC", 0)
 
 Func Main()
-    Local $_configPath = @ScriptDir & "\keypadconfig.ini"
-    Local Const $_scansPerSec = 1000
-    Local Const $_msPerScan = 1000 / $_scansPerSec
-    Local $_loopPeriod, $_loopStartTime, $_timer
-    Local $_timerRetrying
-
     _CommSetDllPath(@ScriptDir & "\Include\commg.dll")
-    If FileExists($_configPath) Then  ; If the config exists then use the binding in it
-        ConfigLoad($_configPath)
+    If FileExists($main_configPath) Then  ; If the config exists then use the binding in it
+        ConfigLoad($main_configPath)
     Else  ; If config doesn't exist then use the default binding
         BindKey(1, "ESC")
         BindKey(2, "`")
@@ -46,12 +46,12 @@ Func Main()
     ; Local $t = 0
     ; Local $tt = 0
     While 1
-        $_loopStartTime = TimerInit()
-        If (TimerDiff($_timer) >= ($_msPerScan - ($_loopPeriod > $_msPerScan ? $_msPerScan : $_loopPeriod))) Then
+        $main_loopStartTime = TimerInit()
+        If (TimerDiff($main_timer) >= ($main_msPerScan - ($main_loopPeriod > $main_msPerScan ? $main_msPerScan : $main_loopPeriod))) Then
         
             ; Because retrieving the port list takes a while, so we don't reconnect too often
-            If $connectionStatus <> $CONNECTED And TimerDiff($_timerRetrying) > 5000 Then
-                $_timerRetrying = TimerInit()
+            If $connectionStatus <> $CONNECTED And TimerDiff($main_timerRetrying) > 5000 Then
+                $main_timerRetrying = TimerInit()
                 Connect()
             EndIf
         
@@ -66,7 +66,7 @@ Func Main()
             ; If TimerDiff($tt) >= 1000 Then
             ;     $tt = TimerInit()
             ;     c($t)
-            ;     c($_loopPeriod)
+            ;     c($main_loopPeriod)
             ;     $t = 0
             ; EndIf
             ; $t += 1
@@ -77,12 +77,12 @@ Func Main()
                 Switch HandleMsg()
                     Case 0
                     Case 1
-                        ConfigSave($_configPath)
+                        ConfigSave($main_configPath)
                 EndSwitch
             EndIf
             
-            $_timer = TimerInit()
-            $_loopPeriod = $_loopPeriod * 0.6 + TimerDiff($_loopStartTime) * 0.4  ; Don't modify the measured loop time immediately as it might float around
+            $main_timer = TimerInit()
+            $main_loopPeriod = $main_loopPeriod * 0.6 + TimerDiff($main_loopStartTime) * 0.4  ; Don't modify the measured loop time immediately as it might float around
         EndIf
     WEnd
 EndFunc

--- a/KeypadDriver/KeypadDriver.au3
+++ b/KeypadDriver/KeypadDriver.au3
@@ -63,15 +63,13 @@ Func Main()
             EndIf
             
             ; Debug loop time and loop frequency output
-            ; If $debug Then
-            ;     If TimerDiff($tt) >= 1000 Then
-            ;         $tt = TimerInit()
-            ;         c($t)
-            ;         c($_loopPeriod)
-            ;         $t = 0
-            ;     EndIf
-            ;     $t += 1
+            ; If TimerDiff($tt) >= 1000 Then
+            ;     $tt = TimerInit()
+            ;     c($t)
+            ;     c($_loopPeriod)
+            ;     $t = 0
             ; EndIf
+            ; $t += 1
             
             If IsGuiOpened() Then
                 SyncGuiRgb()

--- a/KeypadDriver/KeypadDriver.au3
+++ b/KeypadDriver/KeypadDriver.au3
@@ -17,7 +17,7 @@ SetGuiOpeningKey("{F4}")
 Opt("GUICloseOnESC", 0)
 
 Func Main()
-    Local Const $_configPath = @ScriptDir & "\keypadconfig.ini"
+    Local $_configPath = @ScriptDir & "\keypadconfig.ini"
     Local Const $_scansPerSec = 1500
     Local Const $_msPerScan = 1000 / $_scansPerSec
     Local $_loopPeriod, $_loopStartTime, $_timer

--- a/KeypadDriver/KeypadDriver.au3
+++ b/KeypadDriver/KeypadDriver.au3
@@ -18,7 +18,7 @@ Opt("GUICloseOnESC", 0)
 
 Func Main()
     Local $_configPath = @ScriptDir & "\keypadconfig.ini"
-    Local Const $_scansPerSec = 1500
+    Local Const $_scansPerSec = 1000
     Local Const $_msPerScan = 1000 / $_scansPerSec
     Local $_loopPeriod, $_loopStartTime, $_timer
     Local $_timerRetrying


### PR DESCRIPTION
Due to the nature of Autoit, it's often needed to create many global vars, I decided to just prefix all global vars with their corresponding module name, since vars in a module won't be used in any other modules

final solution